### PR TITLE
Fixed a bug with SimpleASF

### DIFF
--- a/desdeo_tools/scalarization/ASF.py
+++ b/desdeo_tools/scalarization/ASF.py
@@ -71,7 +71,7 @@ class SimpleASF(ASFBase):
 
         """
 
-        return np.max(np.where(np.isnan(reference_point), -np.inf, self.weights * (objective_vector - reference_point)))
+        return np.max(np.where(np.isnan(reference_point), -np.inf, self.weights * (objective_vector - reference_point)), axis = -1)
 
 
 class ReferencePointASF(ASFBase):


### PR DESCRIPTION
SimpleASF call always returned a float. Should return a ndarray for input ndarrays with multiple rows.  Does this now: returns a float for n x 1 input and  a ndarray for higher dimensional inputs. 